### PR TITLE
bump version of distribute

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PIL==1.1.7
 Pygments==1.4
 South==0.7.3
 argparse==1.2.1
-distribute==0.6.15
+distribute==0.6.49
 django-debug-toolbar==0.10.2
 django-extensions==0.4.1
 django-haystack==1.0.1-final


### PR DESCRIPTION
I wasn't able to build with pip. Bumping the version fixed the problem. http://wklej.org/hash/f8614ce685b/
